### PR TITLE
gen: update then template to match new action

### DIFF
--- a/gen/atlas.tmpl
+++ b/gen/atlas.tmpl
@@ -3,6 +3,9 @@ on:
   push:
     branches:
       - {{ .DefaultBranch }}
+    paths:
+      - .github/workflows/ci-atlas.yaml
+      - '{{ .Path }}/*'
   pull_request:
     paths:
       - '{{ .Path }}/*'
@@ -11,33 +14,29 @@ permissions:
   contents: read
   pull-requests: write
 jobs:
-  lint:
+  atlas:
     {{- template "services" . }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: ariga/atlas-action@v0
+      - uses: ariga/setup-atlas@v0
         with:
-          dir: '{{ .Path }}'
-{{- with .DirName }}
+          cloud-token: {{`${{ secrets.`}}{{ .SecretName }}{{` }}`}}
+      - uses: ariga/atlas-action/migrate/lint@master
+        with:
+          dir: 'file://{{ .Path }}'
+          {{- with .DirName }}
           dir-name: '{{ . }}'
-{{- end }}
+          {{- end }}
           {{ template "UseServices" (args .Driver "localhost") }}
-          cloud-token: {{`${{ secrets.`}}{{ .SecretName }}{{` }}`}}
-  sync:
-    needs: lint
-    {{- template "services" . }}
-    if: github.ref == 'refs/heads/{{ .DefaultBranch }}'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: ariga/atlas-sync-action@v0
+      - uses: ariga/atlas-action/migrate/push@master
+        if: github.ref == 'refs/heads/master'
         with:
-          dir: '{{ .Path }}'
-{{- with .DirName }}
-          name: '{{ . }}'
-{{- end }}
-          {{ template "UseServices" (args .Driver .Driver) }}
-          cloud-token: {{`${{ secrets.`}}{{ .SecretName }}{{` }}`}}
+            dir: 'file://{{ .Path }}'
+            {{- with .DirName }}
+            dir-name: '{{ . }}'
+            {{- end }}
+            {{ template "UseServices" (args .Driver "localhost") }}
+            cloud-token: {{`${{ secrets.`}}{{ .SecretName }}{{` }}`}}

--- a/gen/atlas.tmpl
+++ b/gen/atlas.tmpl
@@ -24,19 +24,18 @@ jobs:
       - uses: ariga/setup-atlas@v0
         with:
           cloud-token: {{`${{ secrets.`}}{{ .SecretName }}{{` }}`}}
-      - uses: ariga/atlas-action/migrate/lint@master
+      - uses: ariga/atlas-action/migrate/lint@v1
         with:
           dir: 'file://{{ .Path }}'
           {{- with .DirName }}
           dir-name: '{{ . }}'
           {{- end }}
-          {{ template "UseServices" (args .Driver "localhost") }}
-      - uses: ariga/atlas-action/migrate/push@master
+          {{ template "UseServices" . }}
+      - uses: ariga/atlas-action/migrate/push@v1
         if: github.ref == 'refs/heads/master'
         with:
             dir: 'file://{{ .Path }}'
             {{- with .DirName }}
             dir-name: '{{ . }}'
             {{- end }}
-            {{ template "UseServices" (args .Driver "localhost") }}
-            cloud-token: {{`${{ secrets.`}}{{ .SecretName }}{{` }}`}}
+            {{ template "UseServices" . }}

--- a/gen/gen.go
+++ b/gen/gen.go
@@ -35,15 +35,8 @@ var (
 	files embed.FS
 
 	tmpl = template.Must(template.New("atlas-sync-action").
-		Funcs(argsFunc()).
 		ParseFS(files, "*.tmpl"))
 )
-
-func argsFunc() template.FuncMap {
-	return template.FuncMap{"args": func(els ...any) []any {
-		return els
-	}}
-}
 
 // Generate the content of the atlas ci lint yaml.
 func Generate(cfg *Config) ([]byte, error) {

--- a/gen/services.tmpl
+++ b/gen/services.tmpl
@@ -51,15 +51,13 @@
 {{- end }}
 
 {{- define "UseServices" }}
-{{- $Driver := index . 0 }}
-{{- $Host := index . 1 }}
-{{- if eq $Driver "mysql" -}}
-          dev-url: 'mysql://root:pass@{{- $Host }}:3306/dev'
-{{- else if eq $Driver "postgres" -}}
-          dev-url: 'postgres://postgres:pass@{{- $Host }}:5432/dev?search_path=public&sslmode=disable'
-{{- else if eq $Driver "mariadb" -}}
-          dev-url: 'maria://root:pass@{{- $Host }}:3306/dev'
-{{- else if eq $Driver "sqlite" -}}
+{{- if eq .Driver "mysql" -}}
+          dev-url: 'mysql://root:pass@localhost:3306/dev'
+{{- else if eq .Driver "postgres" -}}
+          dev-url: 'postgres://postgres:pass@localhost:5432/dev?search_path=public&sslmode=disable'
+{{- else if eq .Driver "mariadb" -}}
+          dev-url: 'maria://root:pass@localhost:3306/dev'
+{{- else if eq .Driver "sqlite" -}}
           dev-url: 'sqlite://dev?mode=memory'
 {{- end -}}
 {{- end -}}

--- a/gen/testdata/mariadb.yml
+++ b/gen/testdata/mariadb.yml
@@ -3,6 +3,8 @@ on:
   push:
     branches:
       - master
+    paths:
+      - 'migrations/*'
   pull_request:
     paths:
       - 'migrations/*'
@@ -11,7 +13,7 @@ permissions:
   contents: read
   pull-requests: write
 jobs:
-  lint:
+  atlas:
     services:
       # Spin up a mariadb:11 container to be used as the dev-database for analysis.
       mariadb:
@@ -32,36 +34,18 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: ariga/atlas-action@v0
+      - uses: ariga/setup-atlas@v0
         with:
-          dir: 'migrations'
+          cloud-token: ${{ secrets.ATLAS_CLOUD_TOKEN }}
+      - uses: ariga/atlas-action/migrate/lint@master
+        with:
+          dir: 'file://migrations'
           dir-name: 'name'
           dev-url: 'maria://root:pass@localhost:3306/dev'
-          cloud-token: ${{ secrets.ATLAS_CLOUD_TOKEN }}
-  sync:
-    needs: lint
-    services:
-      # Spin up a mariadb:11 container to be used as the dev-database for analysis.
-      mariadb:
-        image: mariadb:11
-        env:
-          MYSQL_DATABASE: dev
-          MYSQL_ROOT_PASSWORD: pass
-        ports:
-          - 3306:3306
-        options: >-
-          --health-cmd "healthcheck.sh --su-mysql --connect --innodb_initialized"
-          --health-interval 10s
-          --health-start-period 10s
-          --health-timeout 5s
-          --health-retries 10
-    if: github.ref == 'refs/heads/master'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: ariga/atlas-sync-action@v0
+      - uses: ariga/atlas-action/migrate/push@master
+        if: github.ref == 'refs/heads/master'
         with:
-          dir: 'migrations'
-          name: 'name'
-          dev-url: 'maria://root:pass@mariadb:3306/dev'
-          cloud-token: ${{ secrets.ATLAS_CLOUD_TOKEN }}
+            dir: 'file://migrations'
+            dir-name: 'name'
+            dev-url: 'maria://root:pass@localhost:3306/dev'
+            cloud-token: ${{ secrets.ATLAS_CLOUD_TOKEN }}

--- a/gen/testdata/mariadb.yml
+++ b/gen/testdata/mariadb.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - master
     paths:
+      - .github/workflows/ci-atlas.yaml
       - 'migrations/*'
   pull_request:
     paths:
@@ -37,15 +38,14 @@ jobs:
       - uses: ariga/setup-atlas@v0
         with:
           cloud-token: ${{ secrets.ATLAS_CLOUD_TOKEN }}
-      - uses: ariga/atlas-action/migrate/lint@master
+      - uses: ariga/atlas-action/migrate/lint@v1
         with:
           dir: 'file://migrations'
           dir-name: 'name'
           dev-url: 'maria://root:pass@localhost:3306/dev'
-      - uses: ariga/atlas-action/migrate/push@master
+      - uses: ariga/atlas-action/migrate/push@v1
         if: github.ref == 'refs/heads/master'
         with:
             dir: 'file://migrations'
             dir-name: 'name'
             dev-url: 'maria://root:pass@localhost:3306/dev'
-            cloud-token: ${{ secrets.ATLAS_CLOUD_TOKEN }}

--- a/gen/testdata/mysql.yml
+++ b/gen/testdata/mysql.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - master
     paths:
+      - .github/workflows/ci-atlas.yaml
       - 'migrations/*'
   pull_request:
     paths:
@@ -37,15 +38,14 @@ jobs:
       - uses: ariga/setup-atlas@v0
         with:
           cloud-token: ${{ secrets.ATLAS_CLOUD_TOKEN }}
-      - uses: ariga/atlas-action/migrate/lint@master
+      - uses: ariga/atlas-action/migrate/lint@v1
         with:
           dir: 'file://migrations'
           dir-name: 'name'
           dev-url: 'mysql://root:pass@localhost:3306/dev'
-      - uses: ariga/atlas-action/migrate/push@master
+      - uses: ariga/atlas-action/migrate/push@v1
         if: github.ref == 'refs/heads/master'
         with:
             dir: 'file://migrations'
             dir-name: 'name'
             dev-url: 'mysql://root:pass@localhost:3306/dev'
-            cloud-token: ${{ secrets.ATLAS_CLOUD_TOKEN }}

--- a/gen/testdata/mysql.yml
+++ b/gen/testdata/mysql.yml
@@ -3,6 +3,8 @@ on:
   push:
     branches:
       - master
+    paths:
+      - 'migrations/*'
   pull_request:
     paths:
       - 'migrations/*'
@@ -11,7 +13,7 @@ permissions:
   contents: read
   pull-requests: write
 jobs:
-  lint:
+  atlas:
     services:
       # Spin up a mysql:8 container to be used as the dev-database for analysis.
       mysql:
@@ -32,36 +34,18 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: ariga/atlas-action@v0
+      - uses: ariga/setup-atlas@v0
         with:
-          dir: 'migrations'
+          cloud-token: ${{ secrets.ATLAS_CLOUD_TOKEN }}
+      - uses: ariga/atlas-action/migrate/lint@master
+        with:
+          dir: 'file://migrations'
           dir-name: 'name'
           dev-url: 'mysql://root:pass@localhost:3306/dev'
-          cloud-token: ${{ secrets.ATLAS_CLOUD_TOKEN }}
-  sync:
-    needs: lint
-    services:
-      # Spin up a mysql:8 container to be used as the dev-database for analysis.
-      mysql:
-        image: mysql:8
-        env:
-          MYSQL_DATABASE: dev
-          MYSQL_ROOT_PASSWORD: pass
-        ports:
-          - 3306:3306
-        options: >-
-          --health-cmd "mysqladmin ping -ppass"
-          --health-interval 10s
-          --health-start-period 10s
-          --health-timeout 5s
-          --health-retries 10
-    if: github.ref == 'refs/heads/master'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: ariga/atlas-sync-action@v0
+      - uses: ariga/atlas-action/migrate/push@master
+        if: github.ref == 'refs/heads/master'
         with:
-          dir: 'migrations'
-          name: 'name'
-          dev-url: 'mysql://root:pass@mysql:3306/dev'
-          cloud-token: ${{ secrets.ATLAS_CLOUD_TOKEN }}
+            dir: 'file://migrations'
+            dir-name: 'name'
+            dev-url: 'mysql://root:pass@localhost:3306/dev'
+            cloud-token: ${{ secrets.ATLAS_CLOUD_TOKEN }}

--- a/gen/testdata/postgres.yml
+++ b/gen/testdata/postgres.yml
@@ -3,6 +3,8 @@ on:
   push:
     branches:
       - master
+    paths:
+      - 'migrations/*'
   pull_request:
     paths:
       - 'migrations/*'
@@ -11,7 +13,7 @@ permissions:
   contents: read
   pull-requests: write
 jobs:
-  lint:
+  atlas:
     services:
       # Spin up a postgres:15 container to be used as the dev-database for analysis.
       postgres:
@@ -32,36 +34,18 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: ariga/atlas-action@v0
+      - uses: ariga/setup-atlas@v0
         with:
-          dir: 'migrations'
+          cloud-token: ${{ secrets.ATLAS_CLOUD_TOKEN }}
+      - uses: ariga/atlas-action/migrate/lint@master
+        with:
+          dir: 'file://migrations'
           dir-name: 'name'
           dev-url: 'postgres://postgres:pass@localhost:5432/dev?search_path=public&sslmode=disable'
-          cloud-token: ${{ secrets.ATLAS_CLOUD_TOKEN }}
-  sync:
-    needs: lint
-    services:
-      # Spin up a postgres:15 container to be used as the dev-database for analysis.
-      postgres:
-        image: postgres:15
-        env:
-          POSTGRES_DB: dev
-          POSTGRES_PASSWORD: pass
-        ports:
-          - 5432:5432
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-start-period 10s
-          --health-timeout 5s
-          --health-retries 5
-    if: github.ref == 'refs/heads/master'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: ariga/atlas-sync-action@v0
+      - uses: ariga/atlas-action/migrate/push@master
+        if: github.ref == 'refs/heads/master'
         with:
-          dir: 'migrations'
-          name: 'name'
-          dev-url: 'postgres://postgres:pass@postgres:5432/dev?search_path=public&sslmode=disable'
-          cloud-token: ${{ secrets.ATLAS_CLOUD_TOKEN }}
+            dir: 'file://migrations'
+            dir-name: 'name'
+            dev-url: 'postgres://postgres:pass@localhost:5432/dev?search_path=public&sslmode=disable'
+            cloud-token: ${{ secrets.ATLAS_CLOUD_TOKEN }}

--- a/gen/testdata/postgres.yml
+++ b/gen/testdata/postgres.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - master
     paths:
+      - .github/workflows/ci-atlas.yaml
       - 'migrations/*'
   pull_request:
     paths:
@@ -37,15 +38,14 @@ jobs:
       - uses: ariga/setup-atlas@v0
         with:
           cloud-token: ${{ secrets.ATLAS_CLOUD_TOKEN }}
-      - uses: ariga/atlas-action/migrate/lint@master
+      - uses: ariga/atlas-action/migrate/lint@v1
         with:
           dir: 'file://migrations'
           dir-name: 'name'
           dev-url: 'postgres://postgres:pass@localhost:5432/dev?search_path=public&sslmode=disable'
-      - uses: ariga/atlas-action/migrate/push@master
+      - uses: ariga/atlas-action/migrate/push@v1
         if: github.ref == 'refs/heads/master'
         with:
             dir: 'file://migrations'
             dir-name: 'name'
             dev-url: 'postgres://postgres:pass@localhost:5432/dev?search_path=public&sslmode=disable'
-            cloud-token: ${{ secrets.ATLAS_CLOUD_TOKEN }}

--- a/gen/testdata/sqlite.yml
+++ b/gen/testdata/sqlite.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - master
     paths:
+      - .github/workflows/ci-atlas.yaml
       - 'migrations/*'
   pull_request:
     paths:
@@ -22,15 +23,14 @@ jobs:
       - uses: ariga/setup-atlas@v0
         with:
           cloud-token: ${{ secrets.ATLAS_CLOUD_TOKEN }}
-      - uses: ariga/atlas-action/migrate/lint@master
+      - uses: ariga/atlas-action/migrate/lint@v1
         with:
           dir: 'file://migrations'
           dir-name: 'name'
           dev-url: 'sqlite://dev?mode=memory'
-      - uses: ariga/atlas-action/migrate/push@master
+      - uses: ariga/atlas-action/migrate/push@v1
         if: github.ref == 'refs/heads/master'
         with:
             dir: 'file://migrations'
             dir-name: 'name'
             dev-url: 'sqlite://dev?mode=memory'
-            cloud-token: ${{ secrets.ATLAS_CLOUD_TOKEN }}

--- a/gen/testdata/sqlite.yml
+++ b/gen/testdata/sqlite.yml
@@ -3,6 +3,8 @@ on:
   push:
     branches:
       - master
+    paths:
+      - 'migrations/*'
   pull_request:
     paths:
       - 'migrations/*'
@@ -11,27 +13,24 @@ permissions:
   contents: read
   pull-requests: write
 jobs:
-  lint:
+  atlas:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: ariga/atlas-action@v0
+      - uses: ariga/setup-atlas@v0
         with:
-          dir: 'migrations'
+          cloud-token: ${{ secrets.ATLAS_CLOUD_TOKEN }}
+      - uses: ariga/atlas-action/migrate/lint@master
+        with:
+          dir: 'file://migrations'
           dir-name: 'name'
           dev-url: 'sqlite://dev?mode=memory'
-          cloud-token: ${{ secrets.ATLAS_CLOUD_TOKEN }}
-  sync:
-    needs: lint
-    if: github.ref == 'refs/heads/master'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: ariga/atlas-sync-action@v0
+      - uses: ariga/atlas-action/migrate/push@master
+        if: github.ref == 'refs/heads/master'
         with:
-          dir: 'migrations'
-          name: 'name'
-          dev-url: 'sqlite://dev?mode=memory'
-          cloud-token: ${{ secrets.ATLAS_CLOUD_TOKEN }}
+            dir: 'file://migrations'
+            dir-name: 'name'
+            dev-url: 'sqlite://dev?mode=memory'
+            cloud-token: ${{ secrets.ATLAS_CLOUD_TOKEN }}


### PR DESCRIPTION
example yaml file:
```yaml
name: Atlas
on:
  push:
    branches:
      - master
    paths:
      - .github/workflows/ci-atlas.yaml
      - 'migrations/*'
  pull_request:
    paths:
      - 'migrations/*'
# Permissions to write comments on the pull request.
permissions:
  contents: read
  pull-requests: write
jobs:
  atlas:
    services:
      # Spin up a mysql:8 container to be used as the dev-database for analysis.
      mysql:
        image: mysql:8
        env:
          MYSQL_DATABASE: dev
          MYSQL_ROOT_PASSWORD: pass
        ports:
          - 3306:3306
        options: >-
          --health-cmd "mysqladmin ping -ppass"
          --health-interval 10s
          --health-start-period 10s
          --health-timeout 5s
          --health-retries 10
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v3
        with:
          fetch-depth: 0
      - uses: ariga/setup-atlas@v0
        with:
          cloud-token: ${{ secrets.ATLAS_CLOUD_TOKEN }}
      - uses: ariga/atlas-action/migrate/lint@master
        with:
          dir: 'file://migrations'
          dir-name: 'name'
          dev-url: 'mysql://root:pass@localhost:3306/dev'
      - uses: ariga/atlas-action/migrate/push@master
        if: github.ref == 'refs/heads/master'
        with:
            dir: 'file://migrations'
            dir-name: 'name'
            dev-url: 'mysql://root:pass@localhost:3306/dev'
            cloud-token: ${{ secrets.ATLAS_CLOUD_TOKEN }}

```