### PR TITLE
bump go release version to v1.21

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,4 +13,4 @@ jobs:
       - uses: actions/checkout@v3
       - uses: cli/gh-extension-precompile@v1
         with:
-          go_version: "1.20"
+          go_version: "1.21"


### PR DESCRIPTION
fix fail to compile go binary:
https://github.com/ariga/gh-atlas/actions/runs/6492412895/job/17631317130#step:3:91
<img width="996" alt="image" src="https://github.com/ariga/gh-atlas/assets/63970571/f0314ac3-2fc7-45c4-b525-71b837907cca">
