### PR TITLE
prompt: show desc for each prompt

### DIFF
--- a/main.go
+++ b/main.go
@@ -13,7 +13,6 @@ import (
 	"github.com/cli/go-gh"
 	"github.com/cli/go-gh/pkg/repository"
 	"github.com/google/go-github/v49/github"
-	"github.com/pkg/browser"
 
 	"ariga.io/gh-atlas/cloudapi"
 	"ariga.io/gh-atlas/gen"
@@ -117,6 +116,9 @@ func (i *InitActionCmd) Run(ctx context.Context, client *githubClient, current r
 		return err
 	case len(dirNames) == 0:
 		return errors.New("no migration directories found in your organization")
+	case len(dirNames) == 1:
+		fmt.Println("Found cloud migration directory:", dirNames[0])
+		i.DirName = dirNames[0]
 	case i.DirName == "":
 		// If the dir name was not provided by the user, set it interactively.
 		if err := i.setDirName(dirNames); err != nil {
@@ -150,7 +152,7 @@ func (i *InitActionCmd) Run(ctx context.Context, client *githubClient, current r
 		return err
 	}
 	fmt.Println("Created PR:", link)
-	if err = browser.OpenURL(link); err != nil {
+	if err = i.openURL(link); err != nil {
 		fmt.Printf("Failed to open %s in browser: %v\n", link, err)
 	}
 	return nil

--- a/prompt.go
+++ b/prompt.go
@@ -242,7 +242,7 @@ func (i *InitActionCmd) setDirName(names []string) error {
 
 func (i *InitActionCmd) openURL(url string) error {
 	prompt := promptui.Prompt{
-		Label:     "Open in browser?",
+		Label:     "Open in browser",
 		IsConfirm: true,
 		Stdin:     i.stdin,
 	}


### PR DESCRIPTION
| **Before**                                                                                                          | **After**                                                                                                           |
|---------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------|
| <img width="806" alt="image" src="https://github.com/user-attachments/assets/78f7757b-39bd-433b-83ad-754b3e81fbb3"> | <img width="777" alt="image" src="https://github.com/user-attachments/assets/8229fb29-9ce6-474f-9e64-76df86856524">|





What’s changing?

There is no change to the output file, only in how we present information to users through the interactive prompt, including:
- Each prompt will have its own description after confirmation.
- Instead of opening the browser directly, ask for confirmation beforehand